### PR TITLE
More precision for relative size difference

### DIFF
--- a/.github/workflows/image_size_diff_latest.yml
+++ b/.github/workflows/image_size_diff_latest.yml
@@ -78,7 +78,7 @@ jobs:
             printf "The image size before this change was: %.2e bytes.\n" "${BASE_SIZE}"
             printf "The image size with this change is: %.2e bytes.\n" "${HEAD_SIZE}"
             printf "Absolute change: %+.2e bytes.\n" "${ABS_INCREASE}"
-            printf "Relative change: %+.0f%%.\n" "${REL_INCREASE}"
+            printf "Relative change: %+.2f%%.\n" "${REL_INCREASE}"
           ) > output
 
           # Even though this is slightly ugly, it's the only way to set multiline

--- a/.github/workflows/image_size_diff_stable.yml
+++ b/.github/workflows/image_size_diff_stable.yml
@@ -92,7 +92,7 @@ jobs:
             printf "The image size before this change was: %.2e bytes.\n" "${BASE_SIZE}"
             printf "The image size with this change is: %.2e bytes.\n" "${HEAD_SIZE}"
             printf "Absolute change: %+.2e bytes.\n" "${ABS_INCREASE}"
-            printf "Relative change: %+.0f%%.\n" "${REL_INCREASE}"
+            printf "Relative change: %+.2f%%.\n" "${REL_INCREASE}"
           ) > output
 
           # Even though this is slightly ugly, it's the only way to set multiline


### PR DESCRIPTION
# Motivation

I wanted **latest** and **stable** to show different results. The current diff report is too imprecise to do that for py2 -> py3 diff that I wanted to make.