### PR TITLE
[demo] Add py3 to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12-alpine
 
 
 
-RUN apk add --no-cache python2 g++ make
+RUN apk add --no-cache python2 python3 g++ make
 
 
 


### PR DESCRIPTION
# Motivation

This PR showcases a situation in which the results of `stable` and `latest` diff reports are different.

# Setup

1) create the PR with base branch `master` with the change that increases the image size (adding py3)
2) send a commit to the `master` branch that increases the image size even more (adding xfce4)
3) send an empty commit to this PR to re-trigger the CI

# Results

The `stable` diff report report doesn't see the `xfce4` addition on base and test.
The `latest` diff report reports does see the `xfce4` addition on base and test.
Because of this the `latest` diff report reports a smaller relative size increase.
